### PR TITLE
Adding Macaron GHA check.

### DIFF
--- a/.github/workflows/macaron-check-github-actions.yml
+++ b/.github/workflows/macaron-check-github-actions.yml
@@ -1,0 +1,38 @@
+name: Macaron check-github-actions
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  workflow_dispatch:
+  schedule:
+    - cron: "17 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  macaron-check-github-actions:
+    name: Macaron policy verification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run Macaron check-github-actions policy
+        uses: oracle/macaron@b31acfe389133a5587d9639063ec70cb84e7bc47 # v0.23.0
+        with:
+          repo_path: https://github.com/${{ github.repository }}
+          policy_file: check-github-actions
+          policy_purl: pkg:github/${{ github.repository }}@${{ github.sha }}
+

--- a/.github/workflows/macaron-check-github-actions.yml
+++ b/.github/workflows/macaron-check-github-actions.yml
@@ -34,5 +34,5 @@ jobs:
         with:
           repo_path: https://github.com/${{ github.repository }}
           policy_file: check-github-actions
-          policy_purl: pkg:github/${{ github.repository }}@${{ github.event.pull_request.head.sha }}
+          policy_purl: pkg:github/${{ github.repository }}@${{ github.sha }}
 

--- a/.github/workflows/macaron-check-github-actions.yml
+++ b/.github/workflows/macaron-check-github-actions.yml
@@ -34,5 +34,5 @@ jobs:
         with:
           repo_path: https://github.com/${{ github.repository }}
           policy_file: check-github-actions
-          policy_purl: pkg:github/${{ github.repository }}@${{ github.sha }}
+          policy_purl: pkg:github/${{ github.repository }}@${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/maven-macos.yml
+++ b/.github/workflows/maven-macos.yml
@@ -18,9 +18,9 @@ jobs:
         java: [ 21, 25 ]
     name: OLCUT - macOS Java SE ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Java Development Kits built by Oracle
-        uses: oracle-actions/setup-java@v1.5.0
+        uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
         with:
           release: ${{ matrix.java }}
       - name: Build with Maven
@@ -29,9 +29,9 @@ jobs:
     runs-on: macos-latest
     name: OLCUT - macOS Java SE 17
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Oracle Java SE
-        uses: oracle-actions/setup-java@v1.4.0
+        uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
         with:
           website: oracle.com
           release: 17

--- a/.github/workflows/maven-macos.yml
+++ b/.github/workflows/maven-macos.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: {}
+
 jobs:
   build:
     runs-on: macos-latest

--- a/.github/workflows/maven-macos.yml
+++ b/.github/workflows/maven-macos.yml
@@ -21,6 +21,8 @@ jobs:
     name: OLCUT - macOS Java SE ${{ matrix.java }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Java Development Kits built by Oracle
         uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
         with:
@@ -32,6 +34,8 @@ jobs:
     name: OLCUT - macOS Java SE 17
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Oracle Java SE
         uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
         with:

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -18,9 +18,9 @@ jobs:
         java: [ 21, 25 ]
     name: OLCUT - Ubuntu Java SE ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Java Development Kits built by Oracle
-        uses: oracle-actions/setup-java@v1.5.0
+        uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
         with:
           release: ${{ matrix.java }}
       - name: Build with Maven
@@ -29,9 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     name: OLCUT - Ubuntu Java SE 17
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Oracle Java SE
-        uses: oracle-actions/setup-java@v1.4.0
+        uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
         with:
           website: oracle.com
           release: 17

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -21,6 +21,8 @@ jobs:
     name: OLCUT - Ubuntu Java SE ${{ matrix.java }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Java Development Kits built by Oracle
         uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
         with:
@@ -32,6 +34,8 @@ jobs:
     name: OLCUT - Ubuntu Java SE 17
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Oracle Java SE
         uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
         with:

--- a/.github/workflows/maven-windows.yml
+++ b/.github/workflows/maven-windows.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: {}
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/maven-windows.yml
+++ b/.github/workflows/maven-windows.yml
@@ -18,9 +18,9 @@ jobs:
         java: [ 21, 25 ]
     name: OLCUT - Windows Java SE ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Java Development Kits built by Oracle
-        uses: oracle-actions/setup-java@v1.5.0
+        uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
         with:
           release: ${{ matrix.java }}
       - name: Build with Maven
@@ -29,9 +29,9 @@ jobs:
     runs-on: windows-latest
     name: OLCUT - Windows Java SE 17
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Oracle Java SE
-        uses: oracle-actions/setup-java@v1.4.0
+        uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
         with:
           website: oracle.com
           release: 17

--- a/.github/workflows/maven-windows.yml
+++ b/.github/workflows/maven-windows.yml
@@ -21,6 +21,8 @@ jobs:
     name: OLCUT - Windows Java SE ${{ matrix.java }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Java Development Kits built by Oracle
         uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
         with:
@@ -32,6 +34,8 @@ jobs:
     name: OLCUT - Windows Java SE 17
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Oracle Java SE
         uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
         with:


### PR DESCRIPTION
## Summary
Add Macaron policy verification for GitHub Actions using the `check-github-actions` policy.

## What this change does
- Adds a dedicated workflow for Macaron verification
- Checks workflow definitions and local composite actions
- Uses pinned actions and disables persisted checkout credentials

## Why this is required
This helps detect unsafe or vulnerable GitHub Actions usage and reduces risk from software supply chain attacks targeting CI/CD pipelines.

## Required follow-up
- Enable `Macaron policy verification` as a required status check for protected branches
- Resolve any policy findings before merge if applicable